### PR TITLE
Handle unsupported types without failing

### DIFF
--- a/src/Guesser/StubAsGuesser/StubAsBackedEnumGuesser.php
+++ b/src/Guesser/StubAsGuesser/StubAsBackedEnumGuesser.php
@@ -6,6 +6,7 @@ use BackedEnum;
 use Ingenerator\StubObjects\Attribute\StubAs;
 use Ingenerator\StubObjects\Attribute\StubAs\StubAsBackedEnum;
 use Ingenerator\StubObjects\Guesser\StubAsGuesser;
+use Ingenerator\StubObjects\ReflectionUtils;
 use Ingenerator\StubObjects\StubbingContext;
 use ReflectionProperty;
 
@@ -13,16 +14,12 @@ class StubAsBackedEnumGuesser implements StubAsGuesser
 {
     public function guessCaster(ReflectionProperty $property, StubbingContext $context): false|StubAs
     {
-        if ( ! $property->getType()) {
+        if (ReflectionUtils::isBuiltinType($property)) {
             return FALSE;
         }
 
-        if ($property->getType()->isBuiltin()) {
-            return FALSE;
-        }
-
-        $type = $property->getType()->getName();
-        if (is_a($type, BackedEnum::class, TRUE)) {
+        $type = ReflectionUtils::getTypeNameIfAvailable($property);
+        if ($type && is_a($type, BackedEnum::class, TRUE)) {
             return new StubAsBackedEnum($type);
         }
 

--- a/src/Guesser/StubAsGuesser/StubAsCollectionGuesser.php
+++ b/src/Guesser/StubAsGuesser/StubAsCollectionGuesser.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Collections\Collection;
 use Ingenerator\StubObjects\Attribute\StubAs;
 use Ingenerator\StubObjects\Attribute\StubAs\StubAsCollection;
 use Ingenerator\StubObjects\Guesser\StubAsGuesser;
+use Ingenerator\StubObjects\ReflectionUtils;
 use Ingenerator\StubObjects\StubbingContext;
 use ReflectionProperty;
 
@@ -13,8 +14,7 @@ class StubAsCollectionGuesser implements StubAsGuesser
 {
     public function guessCaster(ReflectionProperty $property, StubbingContext $context): false|StubAs
     {
-        // @todo: test with untyped props
-        if ($property->getType()?->getName() === Collection::class) {
+        if (ReflectionUtils::getTypeNameIfAvailable($property) === Collection::class) {
             $collected_class = $this->parseItemClass($property);
 
             return new StubAsCollection($property->getType()->getName(), $collected_class);

--- a/src/Guesser/StubAsGuesser/StubAsDateTimeGuesser.php
+++ b/src/Guesser/StubAsGuesser/StubAsDateTimeGuesser.php
@@ -6,6 +6,7 @@ use DateTimeImmutable;
 use Ingenerator\StubObjects\Attribute\StubAs;
 use Ingenerator\StubObjects\Attribute\StubAs\StubAsDateTime;
 use Ingenerator\StubObjects\Guesser\StubAsGuesser;
+use Ingenerator\StubObjects\ReflectionUtils;
 use Ingenerator\StubObjects\StubbingContext;
 use ReflectionProperty;
 
@@ -13,8 +14,7 @@ class StubAsDateTimeGuesser implements StubAsGuesser
 {
     public function guessCaster(ReflectionProperty $property, StubbingContext $context): false|StubAs
     {
-        // @todo test with untyped props
-        if ($property->getType()?->getName() === DateTimeImmutable::class) {
+        if (ReflectionUtils::getTypeNameIfAvailable($property) === DateTimeImmutable::class) {
             return new StubAsDateTime();
         }
 

--- a/src/Guesser/StubAsGuesser/StubAsStubObjectGuesser.php
+++ b/src/Guesser/StubAsGuesser/StubAsStubObjectGuesser.php
@@ -5,6 +5,7 @@ namespace Ingenerator\StubObjects\Guesser\StubAsGuesser;
 use Ingenerator\StubObjects\Attribute\StubAs;
 use Ingenerator\StubObjects\Attribute\StubAs\StubAsStubObject;
 use Ingenerator\StubObjects\Guesser\StubAsGuesser;
+use Ingenerator\StubObjects\ReflectionUtils;
 use Ingenerator\StubObjects\StubbingContext;
 use ReflectionProperty;
 
@@ -12,12 +13,11 @@ class StubAsStubObjectGuesser implements StubAsGuesser
 {
     public function guessCaster(ReflectionProperty $property, StubbingContext $context): false|StubAs
     {
-        // @todo: test with untyped props
-        if ($property->getType()?->isBuiltin()) {
+        if (ReflectionUtils::isBuiltinType($property)) {
             return FALSE;
         }
 
-        $class = $property->getType()?->getName();
+        $class = ReflectionUtils::getTypeNameIfAvailable($property);
         if ($class && $context->isStubbable($class)) {
             return new StubAsStubObject($class);
         }

--- a/src/Guesser/StubDefaultGuesser/StubDefaultDateTimeGuesser.php
+++ b/src/Guesser/StubDefaultGuesser/StubDefaultDateTimeGuesser.php
@@ -6,14 +6,15 @@ use DateTimeImmutable;
 use Ingenerator\StubObjects\Attribute\StubDefault;
 use Ingenerator\StubObjects\Attribute\StubDefault\StubDefaultValue;
 use Ingenerator\StubObjects\Guesser\StubDefaultGuesser;
+use Ingenerator\StubObjects\ReflectionUtils;
 use Ingenerator\StubObjects\StubbingContext;
 use ReflectionProperty;
 
-class StubDefualtDateTimeGuesser implements StubDefaultGuesser
+class StubDefaultDateTimeGuesser implements StubDefaultGuesser
 {
     public function guessProvider(ReflectionProperty $property, StubbingContext $context): false|StubDefault
     {
-        if ($property->getType()->getName() === DateTimeImmutable::class) {
+        if (ReflectionUtils::getTypeNameIfAvailable($property) === DateTimeImmutable::class) {
             // Note that we're guessing this in string form, converting back to a DateTime happens at the
             // point of hydrating values because we anyway need to do it there for values that came in overrides
             return new StubDefaultValue('now');

--- a/src/Guesser/StubDefaultGuesser/StubDefaultStringGuesser.php
+++ b/src/Guesser/StubDefaultGuesser/StubDefaultStringGuesser.php
@@ -5,6 +5,7 @@ namespace Ingenerator\StubObjects\Guesser\StubDefaultGuesser;
 use Ingenerator\StubObjects\Attribute\StubDefault;
 use Ingenerator\StubObjects\Attribute\StubDefault\StubDefaultRandomString;
 use Ingenerator\StubObjects\Guesser\StubDefaultGuesser;
+use Ingenerator\StubObjects\ReflectionUtils;
 use Ingenerator\StubObjects\StubbingContext;
 use Random\Randomizer;
 use ReflectionProperty;
@@ -19,7 +20,7 @@ class StubDefaultStringGuesser implements StubDefaultGuesser
 
     public function guessProvider(ReflectionProperty $property, StubbingContext $context): false|StubDefault
     {
-        if ($property->getType()->getName() === 'string') {
+        if (ReflectionUtils::getTypeNameIfAvailable($property) === 'string') {
             // @todo: guess email addresses for props with `email` in the name
             // @todo: guess URLs for props with `url` in the name
             return new StubDefaultRandomString(

--- a/src/Guesser/StubDefaultGuesser/StubDefaultStubbableObjectGuesser.php
+++ b/src/Guesser/StubDefaultGuesser/StubDefaultStubbableObjectGuesser.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Collections\Collection;
 use Ingenerator\StubObjects\Attribute\StubDefault;
 use Ingenerator\StubObjects\Attribute\StubDefault\StubDefaultValue;
 use Ingenerator\StubObjects\Guesser\StubDefaultGuesser;
+use Ingenerator\StubObjects\ReflectionUtils;
 use Ingenerator\StubObjects\StubbingContext;
 use ReflectionProperty;
 
@@ -13,7 +14,7 @@ class StubDefaultStubbableObjectGuesser implements StubDefaultGuesser
 {
     public function guessProvider(ReflectionProperty $property, StubbingContext $context): false|StubDefault
     {
-        if ($property->getType()->isBuiltin()) {
+        if (ReflectionUtils::isBuiltinType($property)) {
             return FALSE;
         }
 
@@ -29,18 +30,19 @@ class StubDefaultStubbableObjectGuesser implements StubDefaultGuesser
 
     private function isStubbable(StubbingContext $context, ReflectionProperty $property): bool
     {
-        $type = $property->getType();
-        if ($type->isBuiltin()) {
+        $name = ReflectionUtils::getTypeNameIfAvailable($property);
+
+        if ($name === FALSE) {
             return FALSE;
         }
 
-        if ($type->getName() === Collection::class) {
+        if ($name === Collection::class) {
             // Treat collections as a special case, we'll recursively attempt to cast arrays to collections
             return TRUE;
         }
 
         // Otherwise it depends if they've configured recursion
-        return $context->isStubbable($property->getType()->getName());
+        return $context->isStubbable($name);
     }
 
 }

--- a/src/ReflectionUtils.php
+++ b/src/ReflectionUtils.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Ingenerator\StubObjects;
+
+use ReflectionNamedType;
+use ReflectionProperty;
+
+class ReflectionUtils
+{
+
+    public static function isBuiltinType(ReflectionProperty $property): bool
+    {
+        $type = $property->getType();
+
+        return ($type instanceof ReflectionNamedType) && $type->isBuiltin();
+    }
+
+    public static function getTypeNameIfAvailable(ReflectionProperty $property): false|string
+    {
+        $type = $property->getType();
+        if ($type instanceof \ReflectionNamedType) {
+            return $type->getName();
+        }
+
+        return FALSE;
+    }
+}

--- a/src/StandardConfig.php
+++ b/src/StandardConfig.php
@@ -8,10 +8,10 @@ use Ingenerator\StubObjects\Guesser\StubAsGuesser\StubAsCollectionGuesser;
 use Ingenerator\StubObjects\Guesser\StubAsGuesser\StubAsDateTimeGuesser;
 use Ingenerator\StubObjects\Guesser\StubAsGuesser\StubAsStubObjectGuesser;
 use Ingenerator\StubObjects\Guesser\StubDefaultGuesser;
+use Ingenerator\StubObjects\Guesser\StubDefaultGuesser\StubDefaultDateTimeGuesser;
 use Ingenerator\StubObjects\Guesser\StubDefaultGuesser\StubDefaultNullGuesser;
 use Ingenerator\StubObjects\Guesser\StubDefaultGuesser\StubDefaultStringGuesser;
 use Ingenerator\StubObjects\Guesser\StubDefaultGuesser\StubDefaultStubbableObjectGuesser;
-use Ingenerator\StubObjects\Guesser\StubDefaultGuesser\StubDefualtDateTimeGuesser;
 
 class StandardConfig
 {
@@ -36,7 +36,7 @@ class StandardConfig
     {
         return [
             new StubDefaultNullGuesser(),
-            new StubDefualtDateTimeGuesser(),
+            new StubDefaultDateTimeGuesser(),
             new StubDefaultStringGuesser(),
             new StubDefaultStubbableObjectGuesser(),
         ];

--- a/test/integration/HandlesUnsupportedTypesTest.php
+++ b/test/integration/HandlesUnsupportedTypesTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace test\integration;
+
+use Ingenerator\StubObjects\Attribute\StubDefault\StubDefaultValue;
+use Ingenerator\StubObjects\StubObjects;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+class HandlesUnsupportedTypesTest extends TestCase
+{
+
+    #[TestWith([[], ['something' => 'default']])]
+    #[TestWith([['something' => 'whatever'], ['something' => 'whatever']])]
+    public function test_it_can_stub_objects_with_union_types(array $data, array $expect)
+    {
+        $class = new class {
+            #[StubDefaultValue('default')]
+            public bool|string $something;
+        };
+
+        $result = $this->newSubject()->stub($class::class, $data);
+
+        $this->assertSame($expect, (array) $result);
+    }
+
+    #[TestWith([[], ['something' => null]])]
+    #[TestWith([['something' => 'whatever'], ['something' => 'whatever']])]
+    public function test_it_can_stub_objects_with_untyped_properties(array $data, array $expect)
+    {
+        $class = new class {
+            // Note: this will be auto-detected as able to be stubbed with `null`, which is technically correct.
+            public $something;
+        };
+
+        $result = $this->newSubject()->stub($class::class, $data);
+
+        $this->assertSame($expect, (array) $result);
+    }
+
+
+    private function newSubject(array $stubbable_class_patterns = ['*']): StubObjects
+    {
+        return new StubObjects(...get_defined_vars());
+    }
+}

--- a/test/unit/Guesser/StubDefault/StubDefaultDateTimeGuesserTest.php
+++ b/test/unit/Guesser/StubDefault/StubDefaultDateTimeGuesserTest.php
@@ -5,7 +5,7 @@ namespace test\unit\Guesser\StubDefault;
 
 use DateTimeImmutable;
 use Ingenerator\StubObjects\Attribute\StubDefault\StubDefaultValue;
-use Ingenerator\StubObjects\Guesser\StubDefaultGuesser\StubDefualtDateTimeGuesser;
+use Ingenerator\StubObjects\Guesser\StubDefaultGuesser\StubDefaultDateTimeGuesser;
 
 class StubDefaultDateTimeGuesserTest extends BaseStubDefaultGuesserTestCase
 {
@@ -22,7 +22,7 @@ class StubDefaultDateTimeGuesserTest extends BaseStubDefaultGuesserTestCase
                 'string' => FALSE,
             ],
             $class::class,
-            new StubDefualtDateTimeGuesser,
+            new StubDefaultDateTimeGuesser,
         );
     }
 }


### PR DESCRIPTION
We need to cope with:

* untyped properties (which default to null)
* Union types
* Intersection types

We can't guess anything for the latter two, as there's no reliable way to guess which of the supported types might be appropriate. So we just need the guessers to skip over them - previously they were failing due to the ReflectionUnionType / ReflectionIntersectionType not supporting getName() / isBuiltIn().